### PR TITLE
Add oneline battle detail page ui

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -16,6 +16,7 @@ import ProfileSetting from './features/user/ProfileSetting'
 import Leaderboards from './features/user/Leaderboards'
 import OnlineBattles from './features/battle/OnlineBattles'
 import KanjiStack from './features/kanji/KanjiStack'
+import BattleDetail from './features/battle/BattleDetail'
 
 function App() {
   return (
@@ -34,6 +35,7 @@ function App() {
         <Route path="/" element={<Home />} />
         <Route path="/kanji" element={<KanjiStack />} />
         <Route path="/battles" element={<OnlineBattles />} />
+        <Route path="/battle/:id" element={<BattleDetail />} />
         <Route path="/leaderboard" element={<Leaderboards />} />
 
         {/* PRIVATE ROUTES */}

--- a/client/src/components/CustomDivider.tsx
+++ b/client/src/components/CustomDivider.tsx
@@ -1,0 +1,17 @@
+import React from 'react'
+import { Divider, type DividerProps } from 'antd'
+
+interface PropsType extends DividerProps {
+  className?: string
+}
+
+const CustomDivider = ({ className, ...props }: PropsType) => {
+  return (
+    <Divider
+      {...props}
+      className={`rounded-full bg-text-light opacity-10 dark:bg-text-dark ${className}`}
+    />
+  )
+}
+
+export default CustomDivider

--- a/client/src/components/Layouts/DefaultLayout.tsx
+++ b/client/src/components/Layouts/DefaultLayout.tsx
@@ -4,8 +4,10 @@ import { motion, AnimatePresence } from 'framer-motion'
 import Header from './Header'
 import SideBar from './SideBar'
 import Footer from './Footer'
+import { BreadcrumbItem } from './Header/Breadcrumb'
 
 type PropsType = {
+  breadcrumbs?: BreadcrumbItem[]
   className?: string
   children: React.ReactNode
 }
@@ -19,7 +21,7 @@ const variants = {
   exit: { opacity: 0 }
 }
 
-const DefaultLayout = ({ className, children }: PropsType) => {
+const DefaultLayout = ({ breadcrumbs, className, children }: PropsType) => {
   return (
     <AnimatePresence
       initial={true}
@@ -30,7 +32,7 @@ const DefaultLayout = ({ className, children }: PropsType) => {
       }}
     >
       <div className="h-screen w-screen overflow-y-auto bg-app-light text-text-light dark:bg-app-dark dark:text-text-dark">
-        <Header />
+        <Header breadcrumbs={breadcrumbs} />
 
         <div className="flex h-max items-start justify-start">
           <SideBar />

--- a/client/src/components/Layouts/Header/Breadcrumb.tsx
+++ b/client/src/components/Layouts/Header/Breadcrumb.tsx
@@ -1,0 +1,46 @@
+import React, { Fragment, ReactNode } from 'react'
+import { Link } from 'react-router-dom'
+import { BiSolidChevronRight } from 'react-icons/bi'
+import IconWrapper from '~/components/IconWrapper'
+
+export type BreadcrumbItem = {
+  label: ReactNode
+  to: string
+}
+
+type PropsType = {
+  items: BreadcrumbItem[]
+}
+
+const Breadcrumb = ({ items }: PropsType) => {
+  return (
+    <div className="flex-center gap-2">
+      <>
+        {items.slice(0, -1).map((item, index) => (
+          <Fragment key={`breadcumb-item-${index}`}>
+            <Link
+              className="text-base font-medium text-text-secondary-light dark:text-text-secondary-dark"
+              to={item.to}
+            >
+              {item.label}
+            </Link>
+
+            <IconWrapper
+              icon={<BiSolidChevronRight />}
+              className="text-xl text-text-secondary-light dark:text-text-secondary-dark"
+            />
+          </Fragment>
+        ))}
+      </>
+
+      <Link
+        className="text-base font-medium text-clr-link-light dark:text-clr-link-dark"
+        to={items.at(-1)?.to ?? ''}
+      >
+        {items.at(-1)?.label}
+      </Link>
+    </div>
+  )
+}
+
+export default Breadcrumb

--- a/client/src/components/Layouts/Header/index.tsx
+++ b/client/src/components/Layouts/Header/index.tsx
@@ -4,20 +4,29 @@ import { useNavigate } from 'react-router-dom'
 
 import useAuth from '~/hooks/useAuth'
 import AppIcon from '~/assets/app-icon.svg'
+import Breadcrumb, { BreadcrumbItem } from './Breadcrumb'
 import Button from '~/components/Button'
 import IconWrapper from '~/components/IconWrapper'
 import ThemeButton from './ThemeButton'
 import UserButton from './UserButton'
 
-const Header = () => {
+type PropsType = {
+  breadcrumbs?: BreadcrumbItem[]
+}
+
+const Header = ({ breadcrumbs }: PropsType) => {
   const navigate = useNavigate()
   const { email } = useAuth()
 
   return (
     <div className="sticky top-0 z-50 flex w-full items-center justify-between bg-gradient-to-r from-header-light-start from-50% to-header-end px-6 py-3 backdrop-blur-lg dark:from-rgb-gray-0">
-      <div className="app-icon flex-start group cursor-pointer gap-1.5 rounded border-app-icon border-neutral-13 bg-white px-1.5 py-1 text-neutral-13 shadow-light-app-icon transition-all hover:border-white hover:bg-neutral-13 hover:text-white hover:shadow-light-app-icon-hover active:scale-90 dark:invert">
-        <img src={AppIcon} alt="app-icon" className="aspect-square w-[28px] group-hover:invert" />
-        <p className="select-none text-xl">KANJIGAMI</p>
+      <div className="flex-center gap-8">
+        <div className="app-icon flex-start group cursor-pointer gap-1.5 rounded border-app-icon border-neutral-13 bg-white px-1.5 py-1 text-neutral-13 shadow-light-app-icon transition-all hover:border-white hover:bg-neutral-13 hover:text-white hover:shadow-light-app-icon-hover active:scale-90 dark:invert">
+          <img src={AppIcon} alt="app-icon" className="aspect-square w-[28px] group-hover:invert" />
+          <p className="select-none text-xl">KANJIGAMI</p>
+        </div>
+
+        <Breadcrumb items={breadcrumbs ?? []} />
       </div>
 
       <div className="flex-center gap-4">

--- a/client/src/components/PageHeader.tsx
+++ b/client/src/components/PageHeader.tsx
@@ -4,7 +4,7 @@ import { IconType } from 'react-icons/lib'
 import IconWrapper from './IconWrapper'
 
 type PropsType = {
-  icon: ReactElement<IconType>
+  icon?: ReactElement<IconType>
   title: string
   subtitle?: string
   className?: string
@@ -13,14 +13,20 @@ type PropsType = {
 
 const PageHeader = ({ icon, title, subtitle, className, children }: PropsType) => {
   return (
-    <div className={`flex-center w-full flex-col gap-4 ${className ?? ''}`}>
-      <IconWrapper icon={icon} className="text-4xl" />
+    <div
+      className={`flex-center mx-auto max-w-[25rem] flex-col gap-4 text-center ${className ?? ''}`}
+    >
+      {icon && <IconWrapper icon={icon} className="text-4xl" />}
 
       <p className="text-2xl font-semibold text-text-heading-light dark:text-text-heading-dark">
         {title}
       </p>
 
-      {subtitle && <p className="text-base font-medium">{subtitle}</p>}
+      {subtitle && (
+        <p className="text-base font-medium text-text-secondary-light dark:text-text-secondary-dark">
+          {subtitle}
+        </p>
+      )}
 
       {children}
     </div>

--- a/client/src/components/Panel.tsx
+++ b/client/src/components/Panel.tsx
@@ -8,7 +8,7 @@ type PropsType = {
 const Panel = ({ className, children }: PropsType) => {
   return (
     <div
-      className={`h-auto w-full rounded-lg bg-gradient-to-tr from-panel-light-start from-10% to-panel-light-end to-100% p-8 shadow-light-panel dark:from-rgb-gray-1-0.75 dark:to-rgb-gray-0-563 dark:shadow-dark-panel ${
+      className={`h-auto w-full rounded-lg bg-gradient-to-tr from-panel-light-start from-10% to-panel-light-end to-100% p-8 shadow-light-panel dark:from-rgb-gray-1-0.75 dark:to-rgb-gray-0-0.563 dark:shadow-dark-panel ${
         className ?? ''
       }`}
     >

--- a/client/src/components/StackItem.tsx
+++ b/client/src/components/StackItem.tsx
@@ -13,7 +13,7 @@ type PropsType = {
 const StackItem = ({ imageSrc, stack, hightScore, className }: PropsType) => {
   return (
     <div
-      className={`card-item pointer-events-auto z-10 cursor-pointer rounded-lg bg-gradient-to-tl from-card-light-start from-0% to-card-light-end to-100% p-3 shadow-card hover:translate-y-[-10px] hover:scale-105 hover:opacity-100 active:translate-y-0 dark:from-card-dark-start dark:to-card-dark-end dark:shadow-dark-panel ${
+      className={`card-item pointer-events-auto z-10 cursor-pointer rounded-2xl bg-gradient-to-tl from-card-light-start from-0% to-card-light-end to-100% p-2.5 shadow-card hover:translate-y-[-10px] hover:scale-105 hover:opacity-100 active:translate-y-0 dark:from-card-dark-start dark:to-card-dark-end dark:shadow-dark-panel ${
         className ?? ''
       }`}
     >
@@ -25,11 +25,13 @@ const StackItem = ({ imageSrc, stack, hightScore, className }: PropsType) => {
         />
       </div>
 
-      <p className="my-2 text-lg font-semibold">{stack}</p>
+      <p className="mt-2 px-2 text-lg font-semibold">{stack}</p>
 
-      <div className="flex items-center justify-between">
+      <div className="flex items-center justify-between p-2">
         <div>
-          <p className="text-sm font-medium text-text-secondary">Your hi-score</p>
+          <p className="text-sm font-medium text-text-secondary-light dark:text-text-secondary-dark">
+            Your hi-score
+          </p>
           <p className="text-base font-medium">{hightScore ?? 'Not played'}</p>
         </div>
 

--- a/client/src/components/Tag.tsx
+++ b/client/src/components/Tag.tsx
@@ -10,7 +10,7 @@ const Tag = ({ type = 'custom', title, className }: PropsType) => {
   if (type === 'ongoing')
     return (
       <div
-        className={`select-none rounded bg-polar-green-3 px-1 py-0.5 text-sm font-semibold dark:text-text-light ${
+        className={`select-none rounded bg-polar-green-3 px-2 py-1 text-sm font-medium shadow-button dark:text-text-light ${
           className ?? ''
         }`}
       >
@@ -21,7 +21,7 @@ const Tag = ({ type = 'custom', title, className }: PropsType) => {
   if (type === 'upcoming')
     return (
       <div
-        className={`select-none rounded bg-primary-3 px-1 py-0.5 text-sm font-semibold dark:text-text-light ${
+        className={`select-none rounded bg-primary-3 px-2 py-1 text-sm font-medium shadow-button dark:text-text-light ${
           className ?? ''
         }`}
       >
@@ -32,7 +32,7 @@ const Tag = ({ type = 'custom', title, className }: PropsType) => {
   if (type === 'finished')
     return (
       <div
-        className={`select-none rounded bg-dust-red-4 px-1 py-0.5 text-sm font-semibold text-white ${
+        className={`select-none rounded bg-dust-red-4 px-2 py-1 text-sm font-medium text-white shadow-button ${
           className ?? ''
         }`}
       >
@@ -41,7 +41,11 @@ const Tag = ({ type = 'custom', title, className }: PropsType) => {
     )
 
   return (
-    <div className={`select-none rounded px-1 py-0.5 text-sm font-semibold ${className ?? ''}`}>
+    <div
+      className={`select-none rounded bg-clr-border-1-light px-2 py-1 text-sm font-medium shadow-button dark:bg-clr-border-1-dark ${
+        className ?? ''
+      }`}
+    >
       {title ?? 'Custom'}
     </div>
   )

--- a/client/src/features/battle/BattleDetail.tsx
+++ b/client/src/features/battle/BattleDetail.tsx
@@ -1,0 +1,115 @@
+import React from 'react'
+import { RiSwordFill } from 'react-icons/ri'
+import { useParams } from 'react-router-dom'
+
+import { DefaultLayout } from '~/components'
+import CustomDivider from '~/components/CustomDivider'
+import PageHeader from '~/components/PageHeader'
+import Tag from '~/components/Tag'
+import CountDown from './components/CountDown'
+import RootNotification from '~/components/RootNotification'
+import EventLeaderboards from './components/EventLeaderboards'
+import Panel from '~/components/Panel'
+import Button from '~/components/Button'
+import OnlineCard from './components/OnlineCard'
+
+const BattleDetail = () => {
+  const { id: battleId } = useParams()
+
+  return (
+    <DefaultLayout
+      breadcrumbs={[
+        {
+          label: (
+            <div className="flex-center gap-2">
+              <RiSwordFill /> Online battles
+            </div>
+          ),
+          to: '/battles'
+        },
+        {
+          label: <p>{`Mid-Autumn Festival ${battleId}`}</p>,
+          to: `/battle/${battleId}`
+        }
+      ]}
+    >
+      <PageHeader
+        title="Mid-Autumn Festival"
+        subtitle="This is a word package related to the Mid-Autumn Festival. Let's practice kanji together"
+        className="mb-12"
+      >
+        <div className="flex-center gap-2">
+          <Tag type="ongoing" />
+          <Tag title="🥮中秋節" />
+          <Tag title="523 PLAYERS" />
+        </div>
+
+        <div className="flex-center gap-2">
+          <CustomDivider className="my-1" />
+          <div className="whitespace-nowrap rounded-full bg-clr-border-1-light px-3 py-0.5 text-sm uppercase text-footer-light-text dark:bg-clr-border-1-dark">
+            ends in
+          </div>
+          <CustomDivider className="my-1" />
+        </div>
+
+        <CountDown size="large" />
+      </PageHeader>
+
+      <RootNotification />
+
+      <div className="mt-12 flex w-full items-start justify-start gap-12">
+        <div className="w-full grow">
+          <Panel>
+            <div className="grid grid-cols-8 gap-3">
+              {Array.from(Array(12).keys()).map((_, index) => (
+                <Button key={`kanji-item-${index}`}>家族</Button>
+              ))}
+            </div>
+          </Panel>
+
+          <div className="card-list group pointer-events-none mt-6 grid w-full auto-rows-fr grid-cols-auto-fill gap-6">
+            <OnlineCard
+              key={`round-card-64`}
+              imageSrc="https://firebasestorage.googleapis.com/v0/b/kanjigami-61289.appspot.com/o/234.png?alt=media&token=4df8d4e0-c249-466c-9be9-b4db8be3806c"
+              topUsername="Kanji kantan"
+              topScore={253}
+              stack="家族"
+            />
+
+            <OnlineCard
+              key={`round-card-3457`}
+              imageSrc="https://firebasestorage.googleapis.com/v0/b/kanjigami-61289.appspot.com/o/234.png?alt=media&token=4df8d4e0-c249-466c-9be9-b4db8be3806c"
+              topUsername="Kanji kantan"
+              topScore={253}
+              stack="家族"
+            />
+
+            <OnlineCard
+              key={`round-card-347}`}
+              imageSrc="https://firebasestorage.googleapis.com/v0/b/kanjigami-61289.appspot.com/o/234.png?alt=media&token=4df8d4e0-c249-466c-9be9-b4db8be3806c"
+              topUsername="Kanji kantan"
+              topScore={253}
+              stack="家族"
+            />
+
+            {Array.from(Array(5).keys()).map((_, index) => (
+              <OnlineCard key={`round-card-${index}`} />
+            ))}
+          </div>
+        </div>
+
+        <div className="basis-1/4">
+          <Button className="mb-4 w-full" type="primary">
+            Join lobby
+          </Button>
+
+          <p className="mb-4 text-xl font-semibold">Battle leaders</p>
+
+          <EventLeaderboards />
+        </div>
+      </div>
+    </DefaultLayout>
+  )
+}
+
+export default BattleDetail

--- a/client/src/features/battle/OnlineBattles.tsx
+++ b/client/src/features/battle/OnlineBattles.tsx
@@ -3,7 +3,6 @@ import { RiSwordFill } from 'react-icons/ri'
 import { useDocumentTitle } from 'usehooks-ts'
 
 import { DefaultLayout } from '~/components'
-import BattleInfo from '~/components/BattleInfo'
 import Button from '~/components/Button'
 import OnlineRound from '~/components/OnlineRound'
 import PageHeader from '~/components/PageHeader'
@@ -11,6 +10,7 @@ import RootNotification from '~/components/RootNotification'
 import Section from '~/components/Section'
 import EventLeaderboards from './components/EventLeaderboards'
 import Panel from '~/components/Panel'
+import BattleInfo from './components/BattleInfo'
 
 const OnlineBattles = () => {
   useDocumentTitle('Battles | 漢字ガミ')
@@ -34,9 +34,9 @@ const OnlineBattles = () => {
 
       <RootNotification />
 
-      <div className="flex w-full items-start justify-start gap-12">
+      <div className="mt-12 flex w-full items-start justify-start gap-12">
         <div className="w-full grow">
-          <Section title="Latest battles" className="mt-12">
+          <Section title="Latest battles">
             <div className="flex flex-col items-start justify-start gap-8">
               <Panel className="group flex items-start justify-start gap-8">
                 <BattleInfo
@@ -170,7 +170,7 @@ const OnlineBattles = () => {
           </Section>
         </div>
 
-        <div className="mt-12 basis-[30%]">
+        <div className="basis-1/4">
           <p className="mb-4 text-xl font-semibold">All-time leaders</p>
 
           <EventLeaderboards />

--- a/client/src/features/battle/components/BattleInfo.tsx
+++ b/client/src/features/battle/components/BattleInfo.tsx
@@ -1,8 +1,10 @@
 import React from 'react'
-import { Avatar, Divider } from 'antd'
+import { Avatar } from 'antd'
+import { useNavigate } from 'react-router-dom'
 
-import Tag from './Tag'
-import Button from './Button'
+import Tag from '../../../components/Tag'
+import Button from '../../../components/Button'
+import CustomDivider from '~/components/CustomDivider'
 
 type PropsType = {
   status: 'ongoing' | 'upcoming' | 'finished'
@@ -14,6 +16,8 @@ type PropsType = {
 }
 
 const BattleInfo = ({ status, tagName, title, desciption, endTime, className }: PropsType) => {
+  const navigate = useNavigate()
+
   return (
     <div className={`flex w-full flex-col items-start justify-start gap-2 ${className ?? ''}`}>
       <div className="flex items-center justify-start gap-2">
@@ -30,7 +34,7 @@ const BattleInfo = ({ status, tagName, title, desciption, endTime, className }: 
 
       <p className="font-medium">{desciption}</p>
 
-      <Divider className="my-2" />
+      <CustomDivider className="my-2" />
 
       <p className="my-2 font-semibold opacity-70">
         Ends in <span className="">{endTime.getDate()}d</span> : <span>{endTime.getHours()}h</span>{' '}
@@ -58,7 +62,11 @@ const BattleInfo = ({ status, tagName, title, desciption, endTime, className }: 
           </Button>
         )}
 
-        <Button className="px-8" type={status === 'finished' ? 'disabled' : 'primary'}>
+        <Button
+          className="px-8"
+          type={status === 'finished' ? 'disabled' : 'primary'}
+          onClick={() => navigate('/battle/1')}
+        >
           Play
         </Button>
       </div>

--- a/client/src/features/battle/components/CountDown.tsx
+++ b/client/src/features/battle/components/CountDown.tsx
@@ -1,0 +1,55 @@
+import React from 'react'
+
+type PropsType = {
+  size?: 'large' | 'normal'
+  type?: 'full' | 'short'
+}
+
+type TimeItemPropsType = {
+  value: number
+  label: string
+  size?: 'large' | 'normal'
+  isSecond?: boolean
+}
+
+const TimeItem = ({ value, label, size = 'normal', isSecond = false }: TimeItemPropsType) => {
+  return (
+    <div className="flex items-start justify-center gap-1">
+      <div className="flex-center flex-col gap-1">
+        <div
+          className={`flex-center gap-1.5 font-medium ${
+            size === 'normal' ? 'text-lg' : 'text-2xl'
+          }`}
+        >
+          <p className="rounded-lg bg-gradient-to-tl from-count-down-start to-count-down-end px-1.5 py-0.5 text-text-secondary-light dark:from-count-down-dark dark:to-count-down-dark dark:text-text-secondary-dark dark:shadow-timer">
+            0
+          </p>
+
+          <p className="rounded-lg bg-gradient-to-tl from-count-down-start to-count-down-end px-1.5 py-0.5 text-text-secondary-light dark:bg-count-down-dark dark:from-count-down-dark dark:to-count-down-dark dark:text-text-secondary-dark dark:shadow-timer">
+            {value}
+          </p>
+        </div>
+
+        <p className="text-xs font-medium uppercase text-footer-light-text">{label}</p>
+      </div>
+
+      {!isSecond && <p className="text-2xl font-bold text-footer-light-text">:</p>}
+    </div>
+  )
+}
+
+const CountDown = ({ size = 'normal', type = 'full' }: PropsType) => {
+  return (
+    <div className="flex-center gap-1">
+      {type === 'full' && <TimeItem value={1} size={size} label="days" />}
+
+      {type === 'full' && <TimeItem value={1} size={size} label="hours" />}
+
+      <TimeItem value={1} size={size} label="minutes" />
+
+      <TimeItem value={1} size={size} label="seconds" isSecond />
+    </div>
+  )
+}
+
+export default CountDown

--- a/client/src/features/battle/components/OnlineCard.tsx
+++ b/client/src/features/battle/components/OnlineCard.tsx
@@ -1,0 +1,75 @@
+import React from 'react'
+import { FaCrown } from 'react-icons/fa'
+
+import LockedIcon from '~/assets/lock-icon.svg'
+import Avatar from '~/components/Avatar'
+import IconWrapper from '~/components/IconWrapper'
+import CountDown from './CountDown'
+
+type PropsType = {
+  imageSrc?: string
+  topUsername?: string
+  topScore?: number
+  stack?: string
+  className?: string
+}
+
+const OnlineCard = ({ imageSrc, topUsername, topScore, stack, className }: PropsType) => {
+  return (
+    <div
+      className={`card-item flex-center z-10 h-full cursor-pointer flex-col rounded-2xl bg-gradient-to-tl from-card-light-start from-0% to-card-light-end to-100% p-2.5 shadow-card hover:translate-y-[-10px] hover:scale-105 hover:opacity-100 dark:from-card-dark-start dark:to-card-dark-end dark:shadow-dark-panel
+      ${stack ? 'pointer-events-auto' : 'pointer-events-none'}
+      ${className ?? ''}`}
+    >
+      <div className="w-full rounded-lg border-[3px] border-white dark:border-[#111217]">
+        <div
+          className={`relative aspect-ratio rounded-lg transition-transform ${
+            !stack && 'flex-center bg-game-locked'
+          }`}
+        >
+          {stack ? (
+            <>
+              <img
+                src={imageSrc}
+                alt="round-game"
+                className="pointer-events-none max-w-full rounded-lg object-cover"
+              />
+
+              <p className="absolute right-2 top-2 rounded bg-neutral-13 px-1.5 py-0.5 text-sm text-white">
+                {stack}
+              </p>
+            </>
+          ) : (
+            <img src={LockedIcon} alt="locked-icon" className="w-[2.5rem]" />
+          )}
+        </div>
+      </div>
+
+      <div className="flex-center my-2 w-full shrink grow flex-col gap-2">
+        {stack ? (
+          <>
+            <Avatar />
+
+            <div className="flex-center gap-1 text-base font-semibold leading-3">
+              <IconWrapper icon={<FaCrown />} className="text-ranking-1-crown" /> {topUsername}
+            </div>
+
+            <p>{topScore} (34s)</p>
+
+            <div className="w-full rounded-md bg-button-light py-1.5 text-center text-sm font-medium text-button-light-text dark:bg-button-dark dark:text-button-dark-text">
+              You - Not played
+            </div>
+          </>
+        ) : (
+          <div>
+            <p className="mb-4 text-center font-medium text-footer-light-text">Unlock in</p>
+
+            <CountDown type="short" />
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default OnlineCard

--- a/client/src/features/kanji/KanjiStack.tsx
+++ b/client/src/features/kanji/KanjiStack.tsx
@@ -17,8 +17,8 @@ const KanjiStack = () => {
     <DefaultLayout>
       <PageHeader
         icon={<BsStack />}
-        title="Online battles"
-        subtitle="Compete with players around the world"
+        title="Kanji stack"
+        subtitle="Play game and learn more kanji"
         className="mb-12"
       />
 
@@ -47,7 +47,7 @@ const KanjiStack = () => {
         </FilterBox>
       </div>
 
-      <div className="card-list group pointer-events-none row-auto mt-12 grid grid-cols-5 gap-8 transition-opacity">
+      <div className="card-list group pointer-events-none mt-12 grid auto-rows-fr grid-cols-5 gap-8 transition-opacity">
         {Array.from(Array(18).keys()).map(index => (
           <StackItem
             imageSrc="https://firebasestorage.googleapis.com/v0/b/kanjigami-61289.appspot.com/o/213.png?alt=media&token=3eef68c5-c33c-4eb7-99ff-fb4474f405f8"

--- a/client/src/features/user/Components/LeaderboardItem.tsx
+++ b/client/src/features/user/Components/LeaderboardItem.tsx
@@ -25,7 +25,9 @@ const LeaderboardItem = ({ username, score, games, rank }: PropsType) => {
 
         <p>({games} Games)</p>
 
-        <p className="text-xl text-text-secondary">#{rank < 10 ? `0${rank}` : rank}</p>
+        <p className="text-xl text-text-secondary-dark dark:text-text-secondary-light">
+          #{rank < 10 ? `0${rank}` : rank}
+        </p>
       </div>
     </div>
   )

--- a/client/src/features/user/Home.tsx
+++ b/client/src/features/user/Home.tsx
@@ -6,7 +6,6 @@ import { useNavigate } from 'react-router-dom'
 
 import useAuth from '~/hooks/useAuth'
 import { DefaultLayout } from '~/components'
-import BattleInfo from '~/components/BattleInfo'
 import Button from '~/components/Button'
 import OnlineRound from '~/components/OnlineRound'
 import Section from '~/components/Section'
@@ -14,6 +13,7 @@ import StacksList from './Components/StacksList'
 import HomeThumbnail from './Components/HomeThumbnail'
 import RootNotification from '~/components/RootNotification'
 import Panel from '~/components/Panel'
+import BattleInfo from '../battle/components/BattleInfo'
 
 const Home = () => {
   useDocumentTitle('漢字ガミ')

--- a/client/src/features/user/ProfileSetting.tsx
+++ b/client/src/features/user/ProfileSetting.tsx
@@ -8,6 +8,7 @@ import PageHeader from '~/components/PageHeader'
 import Panel from '~/components/Panel'
 import EditUsername from './Components/EditUsername'
 import EditAvatar from './Components/EditAvatar'
+import CustomDivider from '~/components/CustomDivider'
 
 const ProfileSetting = () => {
   useDocumentTitle('Settings | 漢字ガミ')
@@ -20,7 +21,7 @@ const ProfileSetting = () => {
         <form>
           <EditUsername />
 
-          <Divider />
+          <CustomDivider />
 
           <EditAvatar />
         </form>

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -24,7 +24,11 @@ export default {
         'light-app-icon': '4px 4px 0px rgba(0, 0, 0, 0.8)',
         'light-app-icon-hover': '-4px -4px 0px rgba(0, 0, 0, 0.8)',
         'light-panel': '0px 20px 50px rgba(0, 0, 0, 0.07)',
-        'light-side-item': 'inset 1px 1px 2px rgba(0, 0, 0, 0.1)'
+        'light-side-item': 'inset 1px 1px 2px rgba(0, 0, 0, 0.1)',
+        timer: '0 10px 5px -5px rgba(0, 0, 0, .2)'
+      },
+      gridTemplateColumns: {
+        'auto-fill': 'repeat(auto-fill, minmax(14rem, 1fr))'
       },
       height: {
         'main-content': 'calc(100vh - 4rem)'
@@ -72,7 +76,7 @@ export default {
       },
       'rgb-gray': {
         0.75: 'rgba(255, 255, 255, 0.75)',
-        '0-563': 'rgba(24, 29, 35, 0.563)',
+        '0-0.563': 'rgba(24, 29, 35, 0.563)',
         '0-0.75': 'rgba(24, 29, 35, 0.75)',
         '1-0.75': 'rgba(29, 35, 43, 0.75)',
         0: 'rgb(24, 29, 35)',
@@ -93,6 +97,11 @@ export default {
         'light-end': 'rgba(245, 245, 245, 1)',
         'dark-start': 'rgba(45, 55, 64, 0.5)',
         'dark-end': 'rgba(39, 45, 52, 0.5)'
+      },
+      'count-down': {
+        start: '#E7DADA',
+        end: '#E0CFCF',
+        dark: 'rgb(39, 45, 52)'
       },
       'clr-link': {
         light: '#050505',
@@ -115,12 +124,18 @@ export default {
         'start-dark': 'rgb(45, 55, 64)',
         'end-dark': 'rgb(39, 45, 52)'
       },
+      game: {
+        locked: '#252e36'
+      },
       header: {
         end: 'transparent',
         'light-start': 'rgba(255, 255, 255)'
       },
-      game: {
-        locked: '#252e36'
+      input: {
+        light: '#E2E8F0',
+        dark: '#0F1117',
+        'border-light': '#CBD5E0',
+        'border-dark': '#323F4A'
       },
       ranking: {
         'start-light': '#FFFFFF',
@@ -160,7 +175,8 @@ export default {
       text: {
         light: '#1A202C',
         dark: '#CBD1E1',
-        secondary: '#6B7B8E',
+        'secondary-light': '#4A5568',
+        'secondary-dark': '#91A7BE',
         'heading-light': '#050505',
         'heading-dark': '#EFF5FB'
       },
@@ -185,17 +201,8 @@ export default {
         'dark-icon': '#4C5663',
         'dark-icon-hover': '#7C8C9E'
       },
-
-      'count-down-timer': 'linear-gradient(90deg, #E7DADA 0.01%, #E0CFCF 99.99%)',
-
       avatar: {
         outline: '#976E06'
-      },
-      input: {
-        light: '#E2E8F0',
-        dark: '#0F1117',
-        'border-light': '#CBD5E0',
-        'border-dark': '#323F4A'
       }
     }
   },


### PR DESCRIPTION
## I'm submitting a ...

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Update logs:

Please describe the changes.

- [x] Add header breadcrumb navigate menu
- [x] Add custom diver
- [x] Add countdown timer
- [x] Add online battle page ui

## Screenshots (if appropriate):

![online-battle-detail](https://github.com/Thdeathz/kanjigami/assets/78098285/cd21bcf9-263d-4af3-9eab-1468933bbe96)

Author: @Thdeathz 
